### PR TITLE
player profiles, compare, search history, command palette, and UX imp…

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="shortcut icon" type="image/x-icon" href="/favicon.png" />
-    <title>Enhanced Leaderboard – THE FINALS</title>
+    <title>THE FINALS - Enhanced Leaderboard</title>
     <meta
       name="description"
       content="View enhanced leaderboards from THE FINALS video game. Search, filter, and sort the top 10,000 players from the seasonal leaderboards."

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="shortcut icon" type="image/x-icon" href="/favicon.png" />
-    <title>THE FINALS - Enhanced Leaderboard</title>
+    <title>Enhanced Leaderboard – THE FINALS</title>
     <meta
       name="description"
       content="View enhanced leaderboards from THE FINALS video game. Search, filter, and sort the top 10,000 players from the seasonal leaderboards."

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,0 +1,100 @@
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "@/components/ui/command";
+import { useSearchHistory } from "@/hooks/useSearchHistory";
+import { useNavigate } from "@tanstack/react-router";
+import { ClockIcon, SearchIcon, UserRoundIcon } from "lucide-react";
+import { useState } from "react";
+import { useHotkeys } from "react-hotkeys-hook";
+
+export function CommandPalette() {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const navigate = useNavigate();
+  const { history, addToHistory } = useSearchHistory();
+
+  useHotkeys("mod+k", (e) => {
+    e.preventDefault();
+    setOpen((o) => !o);
+  });
+
+  // Search on main leaderboard page — partial match, like the main filter
+  const handleSearch = (name: string) => {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    addToHistory(trimmed);
+    navigate({ to: "/", search: { name: trimmed } });
+    setOpen(false);
+    setQuery("");
+  };
+
+  // Navigate directly to player profile — requires exact name (e.g. Name#1234)
+  const handleProfile = (name: string) => {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    addToHistory(trimmed);
+    navigate({ to: "/players/$playerName", params: { playerName: trimmed } });
+    setOpen(false);
+    setQuery("");
+  };
+
+  return (
+    <CommandDialog open={open} onOpenChange={setOpen}>
+      <CommandInput
+        placeholder="Search for a player..."
+        value={query}
+        onValueChange={setQuery}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && query.trim()) {
+            handleSearch(query.trim());
+          }
+        }}
+      />
+      <CommandList>
+        {query.trim() && (
+          <CommandGroup heading="Search">
+            <CommandItem onSelect={() => handleSearch(query.trim())}>
+              <SearchIcon className="mr-2 size-4 text-neutral-400" />
+              <span>Search for &ldquo;{query.trim()}&rdquo;</span>
+              <span className="ml-auto text-xs text-neutral-400">↵</span>
+            </CommandItem>
+            <CommandItem onSelect={() => handleProfile(query.trim())}>
+              <UserRoundIcon className="mr-2 size-4 text-neutral-400" />
+              <span>Open profile for &ldquo;{query.trim()}&rdquo;</span>
+              <span className="ml-auto text-xs text-neutral-400">
+                exact match
+              </span>
+            </CommandItem>
+          </CommandGroup>
+        )}
+
+        {history.length > 0 && (
+          <>
+            {query.trim() && <CommandSeparator />}
+            <CommandGroup heading="Recent searches">
+              {history.map((name) => (
+                <CommandItem key={name} onSelect={() => handleSearch(name)}>
+                  <ClockIcon className="mr-2 size-4 text-neutral-400" />
+                  {name}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </>
+        )}
+
+        {!query && history.length === 0 && (
+          <CommandEmpty>
+            <SearchIcon className="mx-auto mb-2 size-6 text-neutral-400" />
+            Type a player name to search.
+          </CommandEmpty>
+        )}
+      </CommandList>
+    </CommandDialog>
+  );
+}

--- a/src/components/KeyboardShortcutsDialog.tsx
+++ b/src/components/KeyboardShortcutsDialog.tsx
@@ -1,0 +1,49 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+
+const shortcuts = [
+  { key: "⌘ K", description: "Open player search" },
+  { key: "/", description: "Focus name filter" },
+  { key: "← →", description: "Navigate pages" },
+  { key: "Esc", description: "Clear / close" },
+];
+
+export function KeyboardShortcutsDialog() {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button
+          variant="outline"
+          size="icon"
+          className="size-9 shrink-0 rounded-full text-sm font-semibold shadow-md"
+          title="Keyboard shortcuts"
+        >
+          ?
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-xs font-saira">
+        <DialogHeader>
+          <DialogTitle>Keyboard shortcuts</DialogTitle>
+        </DialogHeader>
+        <div className="flex flex-col gap-3">
+          {shortcuts.map(({ key, description }) => (
+            <div key={key} className="flex items-center justify-between gap-4">
+              <span className="text-sm text-neutral-600 dark:text-neutral-400">
+                {description}
+              </span>
+              <kbd className="shrink-0 rounded border border-neutral-200 bg-neutral-50 px-2 py-1 font-mono text-xs dark:border-neutral-700 dark:bg-neutral-800">
+                {key}
+              </kbd>
+            </div>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/KeyboardShortcutsDialog.tsx
+++ b/src/components/KeyboardShortcutsDialog.tsx
@@ -27,7 +27,7 @@ export function KeyboardShortcutsDialog() {
           ?
         </Button>
       </DialogTrigger>
-      <DialogContent className="sm:max-w-xs font-saira">
+      <DialogContent className="font-saira sm:max-w-xs">
         <DialogHeader>
           <DialogTitle>Keyboard shortcuts</DialogTitle>
         </DialogHeader>

--- a/src/components/tables/DataTablePagination.tsx
+++ b/src/components/tables/DataTablePagination.tsx
@@ -15,6 +15,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "../ui/select";
+import { useHotkeys } from "react-hotkeys-hook";
 
 interface DataTablePaginationProps<TData> {
   table: Table<TData>;
@@ -23,8 +24,42 @@ interface DataTablePaginationProps<TData> {
 export function DataTablePagination<TData>({
   table,
 }: DataTablePaginationProps<TData>) {
+  useHotkeys(
+    "ArrowLeft",
+    () => {
+      if (table.getCanPreviousPage()) table.previousPage();
+    },
+    { enableOnFormTags: false },
+  );
+
+  useHotkeys(
+    "ArrowRight",
+    () => {
+      if (table.getCanNextPage()) table.nextPage();
+    },
+    { enableOnFormTags: false },
+  );
+
   return (
     <div className="flex flex-wrap items-center justify-between gap-1">
+      {table.getCoreRowModel().rows.length > 0 && (
+        <div className="text-sm text-neutral-500">
+          {table.getFilteredRowModel().rows.length <
+          table.getCoreRowModel().rows.length ? (
+            <>
+              <span className="font-medium text-foreground">
+                {table.getFilteredRowModel().rows.length.toLocaleString("en")}
+              </span>
+              {" of "}
+              {table.getCoreRowModel().rows.length.toLocaleString("en")} players
+            </>
+          ) : (
+            <>
+              {table.getCoreRowModel().rows.length.toLocaleString("en")} players
+            </>
+          )}
+        </div>
+      )}
       <div className="flex items-center space-x-2">
         <p className="text-sm font-medium">Rows per page</p>
         <Select

--- a/src/components/tables/LeaderboardDataTable.tsx
+++ b/src/components/tables/LeaderboardDataTable.tsx
@@ -22,7 +22,6 @@ import {
 import { DataTablePagination } from "./DataTablePagination";
 import { LeaderboardId, leaderboards } from "@/utils/leaderboards";
 import { useHotkeys } from "react-hotkeys-hook";
-import Loading from "../Loading";
 import { LeaderboardDataTableToolbar } from "./LeaderboardDataTableToolbar";
 import { useSearch } from "@tanstack/react-router";
 
@@ -125,7 +124,27 @@ export function LeaderboardDataTable<TData, TValue>({
             </TableHeader>
 
             <TableBody>
-              {table.getRowModel().rows?.length ? (
+              {queryState.isLoading ? (
+                Array.from({ length: 10 }).map((_, i) => (
+                  <TableRow key={i} className="animate-pulse">
+                    {columns.map((_, j) => (
+                      <TableCell key={j} className="p-3">
+                        <div
+                          className={`h-5 rounded bg-neutral-200 dark:bg-neutral-700 ${
+                            j === 0
+                              ? "w-8"
+                              : j === 1
+                                ? "w-10"
+                                : j === 2
+                                  ? "w-36"
+                                  : "w-16"
+                          }`}
+                        />
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))
+              ) : table.getRowModel().rows?.length ? (
                 table.getRowModel().rows.map((row) => (
                   <Fragment key={row.id}>
                     <TableRow>
@@ -146,11 +165,7 @@ export function LeaderboardDataTable<TData, TValue>({
                     colSpan={columns.length}
                     className="h-24 text-center"
                   >
-                    {queryState.isLoading ? (
-                      <Loading justifyCenter />
-                    ) : (
-                      "No results."
-                    )}
+                    No results.
                   </TableCell>
                 </TableRow>
               )}

--- a/src/components/tables/LeaderboardDataTableColumns.tsx
+++ b/src/components/tables/LeaderboardDataTableColumns.tsx
@@ -1,5 +1,5 @@
 import { createColumnHelper } from "@tanstack/react-table";
-import { ChevronDown, ChevronUp, Minus } from "lucide-react";
+import { ChevronDown, ChevronUp, ExternalLink, Minus } from "lucide-react";
 import {
   Tooltip,
   TooltipContent,
@@ -12,7 +12,7 @@ import { BaseUser, BaseUserWithExtras, panels } from "@/types";
 import { LeaderboardId, leaderboards } from "@/utils/leaderboards";
 import { SponsorImage } from "../SponsorImage";
 import LeagueImage from "../LeagueImage";
-import { useNavigate } from "@tanstack/react-router";
+import { Link, useNavigate } from "@tanstack/react-router";
 import { PlayStationIcon, SteamIcon, XboxIcon } from "../icons";
 
 const columnHelper = createColumnHelper<BaseUserWithExtras>();
@@ -41,12 +41,12 @@ export const leaderboardDataTableColumns = (
       cell: ({ getValue }) => {
         const value = getValue();
         return value > 0 ? (
-          <span className="inline-flex items-center text-indigo-400 dark:text-indigo-300">
+          <span className="animate-in slide-in-from-bottom-1 inline-flex items-center text-indigo-400 dark:text-indigo-300">
             {<ChevronUp className="inline h-6" />}
             {value.toLocaleString("en")}
           </span>
         ) : value < 0 ? (
-          <span className="inline-flex items-center text-red-500 dark:text-red-500">
+          <span className="animate-in slide-in-from-top-1 inline-flex items-center text-red-500 dark:text-red-500">
             {<ChevronDown className="inline h-6" />}
             {Math.abs(value).toLocaleString("en")}
           </span>
@@ -97,7 +97,7 @@ export const leaderboardDataTableColumns = (
               </Tooltip>
             </TooltipProvider>
           ) : (
-            <span className="inline-flex gap-1">
+            <span className="group/playerlink inline-flex items-center gap-1">
               {/* If platform selection is enabled, add the selected platform icon before the name */}
               {leaderboards[leaderboardId].features.includes(
                 "platformSelection",
@@ -114,7 +114,14 @@ export const leaderboardDataTableColumns = (
                   )}
                 </>
               )}
-              {user.name}
+              <Link
+                to="/players/$playerName"
+                params={{ playerName: user.name }}
+                className="hover:underline"
+              >
+                {user.name}
+              </Link>
+              <ExternalLink className="size-3 opacity-0 transition-opacity group-hover/playerlink:opacity-40" />
             </span>
           );
         },
@@ -314,9 +321,17 @@ const platformNamesInline = (user: BaseUser) => {
       <div>
         <div className="inline-flex gap-1">
           {user.clubTag && <ClickableClubTag clubTag={user.clubTag} />}
-          <span className="font-medium">{user.name.split("#")[0]}</span>
+          <Link
+            to="/players/$playerName"
+            params={{ playerName: user.name }}
+            className="group/namelink inline-flex items-center gap-1 hover:underline"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <span className="font-medium">{user.name.split("#")[0]}</span>
+            <span className="text-neutral-500">#{user.name.split("#")[1]}</span>
+            <ExternalLink className="size-3 opacity-0 transition-opacity group-hover/namelink:opacity-40" />
+          </Link>
         </div>
-        <span className="text-neutral-500">#{user.name.split("#")[1]}</span>
       </div>
 
       <div className="flex flex-wrap gap-1 *:rounded *:bg-neutral-200 *:p-1 *:py-[2px] *:text-xs *:transition-colors *:dark:bg-neutral-800">

--- a/src/components/tables/LeaderboardDataTableColumns.tsx
+++ b/src/components/tables/LeaderboardDataTableColumns.tsx
@@ -41,12 +41,12 @@ export const leaderboardDataTableColumns = (
       cell: ({ getValue }) => {
         const value = getValue();
         return value > 0 ? (
-          <span className="animate-in slide-in-from-bottom-1 inline-flex items-center text-indigo-400 dark:text-indigo-300">
+          <span className="inline-flex items-center text-indigo-400 animate-in slide-in-from-bottom-1 dark:text-indigo-300">
             {<ChevronUp className="inline h-6" />}
             {value.toLocaleString("en")}
           </span>
         ) : value < 0 ? (
-          <span className="animate-in slide-in-from-top-1 inline-flex items-center text-red-500 dark:text-red-500">
+          <span className="inline-flex items-center text-red-500 animate-in slide-in-from-top-1 dark:text-red-500">
             {<ChevronDown className="inline h-6" />}
             {Math.abs(value).toLocaleString("en")}
           </span>

--- a/src/components/tables/LeaderboardDataTableToolbar.tsx
+++ b/src/components/tables/LeaderboardDataTableToolbar.tsx
@@ -1,5 +1,11 @@
 import { Table } from "@tanstack/react-table";
-import { CheckIcon, ClockIcon, DownloadIcon, PlusCircle, XIcon } from "lucide-react";
+import {
+  CheckIcon,
+  ClockIcon,
+  DownloadIcon,
+  PlusCircle,
+  XIcon,
+} from "lucide-react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { useRef, useState } from "react";
 import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
@@ -131,7 +137,9 @@ export function LeaderboardDataTableToolbar<TData>({
               viewTransition: true,
               search: (prev) => ({
                 ...prev,
-                name: event.target.value.length ? event.target.value : undefined,
+                name: event.target.value.length
+                  ? event.target.value
+                  : undefined,
               }),
             });
           }}

--- a/src/components/tables/LeaderboardDataTableToolbar.tsx
+++ b/src/components/tables/LeaderboardDataTableToolbar.tsx
@@ -2,7 +2,6 @@ import { Table } from "@tanstack/react-table";
 import {
   CheckIcon,
   ClockIcon,
-  DownloadIcon,
   PlusCircle,
   XIcon,
 } from "lucide-react";
@@ -71,30 +70,6 @@ export function LeaderboardDataTableToolbar<TData>({
       }),
     });
     setHistoryOpen(false);
-  };
-
-  const handleExportCSV = () => {
-    const cols = table
-      .getVisibleLeafColumns()
-      .filter((c) => c.id !== "actions");
-    const headers = cols.map((c) => c.id);
-    const rows = table.getFilteredRowModel().rows.map((row) =>
-      headers
-        .map((h) => {
-          const val = row.getValue(h);
-          if (val === null || val === undefined) return "";
-          return typeof val === "string" ? `"${val.replace(/"/g, '""')}"` : val;
-        })
-        .join(","),
-    );
-    const csv = [headers.join(","), ...rows].join("\n");
-    const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = `${leaderboardId}.csv`;
-    a.click();
-    URL.revokeObjectURL(url);
   };
 
   const nameColumn = table.getColumn("name")!;
@@ -321,16 +296,6 @@ export function LeaderboardDataTableToolbar<TData>({
         </Popover>
       )}
 
-      <Button
-        variant="outline"
-        size="sm"
-        className="ml-auto h-10 select-none gap-1.5"
-        onClick={handleExportCSV}
-        title="Export current table as CSV"
-      >
-        <DownloadIcon className="size-4" />
-        <span className="hidden sm:inline">Export CSV</span>
-      </Button>
     </div>
   );
 }

--- a/src/components/tables/LeaderboardDataTableToolbar.tsx
+++ b/src/components/tables/LeaderboardDataTableToolbar.tsx
@@ -1,10 +1,5 @@
 import { Table } from "@tanstack/react-table";
-import {
-  CheckIcon,
-  ClockIcon,
-  PlusCircle,
-  XIcon,
-} from "lucide-react";
+import { CheckIcon, ClockIcon, PlusCircle, XIcon } from "lucide-react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { useRef, useState } from "react";
 import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
@@ -295,7 +290,6 @@ export function LeaderboardDataTableToolbar<TData>({
           </PopoverContent>
         </Popover>
       )}
-
     </div>
   );
 }

--- a/src/components/tables/LeaderboardDataTableToolbar.tsx
+++ b/src/components/tables/LeaderboardDataTableToolbar.tsx
@@ -1,7 +1,10 @@
 import { Table } from "@tanstack/react-table";
-import { CheckIcon, PlusCircle } from "lucide-react";
+import { CheckIcon, ClockIcon, DownloadIcon, PlusCircle, XIcon } from "lucide-react";
+import { useHotkeys } from "react-hotkeys-hook";
+import { useRef, useState } from "react";
 import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
 import { Button } from "../ui/button";
+import { useSearchHistory } from "@/hooks/useSearchHistory";
 import {
   Command,
   CommandEmpty,
@@ -35,6 +38,59 @@ export function LeaderboardDataTableToolbar<TData>({
   });
   const navigate = useNavigate();
 
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const [historyOpen, setHistoryOpen] = useState(false);
+  const { history, addToHistory, removeFromHistory } = useSearchHistory();
+
+  useHotkeys(
+    "/",
+    (e) => {
+      e.preventDefault();
+      searchInputRef.current?.focus();
+      searchInputRef.current?.select();
+    },
+    { enableOnFormTags: false },
+  );
+
+  const handleSelectHistory = (selectedName: string) => {
+    if (searchInputRef.current) {
+      searchInputRef.current.value = selectedName;
+    }
+    nameColumn.setFilterValue(selectedName);
+    navigate({
+      viewTransition: true,
+      search: (prev) => ({
+        ...prev,
+        name: selectedName.length ? selectedName : undefined,
+      }),
+    });
+    setHistoryOpen(false);
+  };
+
+  const handleExportCSV = () => {
+    const cols = table
+      .getVisibleLeafColumns()
+      .filter((c) => c.id !== "actions");
+    const headers = cols.map((c) => c.id);
+    const rows = table.getFilteredRowModel().rows.map((row) =>
+      headers
+        .map((h) => {
+          const val = row.getValue(h);
+          if (val === null || val === undefined) return "";
+          return typeof val === "string" ? `"${val.replace(/"/g, '""')}"` : val;
+        })
+        .join(","),
+    );
+    const csv = [headers.join(","), ...rows].join("\n");
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `${leaderboardId}.csv`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
   const nameColumn = table.getColumn("name")!;
   const fameColumn = leaderboards[leaderboardId].features.includes(
     "leagueFilter",
@@ -53,25 +109,73 @@ export function LeaderboardDataTableToolbar<TData>({
 
   return (
     <div className="flex flex-wrap gap-2">
-      <Input
-        type="search"
-        className="max-w-xs select-none data-[active=true]:border-black/50 dark:data-[active=true]:border-white/50"
-        data-active={!!name}
-        placeholder="Filter usernames..."
-        maxLength={20}
-        defaultValue={name}
-        onChange={(event) => {
-          nameColumn.setFilterValue(event.target.value);
+      <div className="group relative max-w-xs flex-1">
+        <Input
+          ref={searchInputRef}
+          type="search"
+          className="w-full select-none pr-12 data-[active=true]:border-black/50 dark:data-[active=true]:border-white/50"
+          data-active={!!name}
+          placeholder="Filter usernames..."
+          maxLength={20}
+          defaultValue={name}
+          onFocus={() => {
+            if (history.length > 0) setHistoryOpen(true);
+          }}
+          onBlur={(e) => {
+            setHistoryOpen(false);
+            if (e.target.value) addToHistory(e.target.value);
+          }}
+          onChange={(event) => {
+            nameColumn.setFilterValue(event.target.value);
+            navigate({
+              viewTransition: true,
+              search: (prev) => ({
+                ...prev,
+                name: event.target.value.length ? event.target.value : undefined,
+              }),
+            });
+          }}
+        />
+        <kbd className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 rounded border border-neutral-200 px-1.5 py-0.5 font-mono text-xs text-neutral-400 transition-opacity group-focus-within:opacity-0 dark:border-neutral-700">
+          /
+        </kbd>
 
-          navigate({
-            viewTransition: true,
-            search: (prev) => ({
-              ...prev,
-              name: event.target.value.length ? event.target.value : undefined,
-            }),
-          });
-        }}
-      />
+        {/* History dropdown */}
+        {historyOpen && history.length > 0 && (
+          <div className="absolute left-0 right-0 top-full z-50 mt-1 overflow-hidden rounded-md border border-neutral-200 bg-white shadow-md dark:border-neutral-700 dark:bg-neutral-900">
+            <div className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold uppercase tracking-wider text-neutral-400">
+              <ClockIcon className="size-3" />
+              Recent searches
+            </div>
+            {history.map((historyName) => (
+              <div
+                key={historyName}
+                className="flex items-center justify-between gap-1 px-3 py-1.5 hover:bg-neutral-100 dark:hover:bg-neutral-800"
+              >
+                <button
+                  className="flex-1 text-left text-sm"
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    handleSelectHistory(historyName);
+                  }}
+                >
+                  {historyName}
+                </button>
+                <button
+                  className="shrink-0 text-neutral-400 hover:text-red-500"
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    removeFromHistory(historyName);
+                  }}
+                  title="Remove from history"
+                >
+                  <XIcon className="size-3" />
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
 
       {leaderboards[leaderboardId].features.includes("leagueFilter") && (
         <Popover>
@@ -208,6 +312,17 @@ export function LeaderboardDataTableToolbar<TData>({
           </PopoverContent>
         </Popover>
       )}
+
+      <Button
+        variant="outline"
+        size="sm"
+        className="ml-auto h-10 select-none gap-1.5"
+        onClick={handleExportCSV}
+        title="Export current table as CSV"
+      >
+        <DownloadIcon className="size-4" />
+        <span className="hidden sm:inline">Export CSV</span>
+      </Button>
     </div>
   );
 }

--- a/src/hooks/useFavorites.ts
+++ b/src/hooks/useFavorites.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from "react";
+
+const STORAGE_KEY = "player-favorites";
+
+export function useFavorites() {
+  const [favorites, setFavorites] = useState<string[]>(() => {
+    try {
+      return JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "[]");
+    } catch {
+      return [];
+    }
+  });
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(favorites));
+  }, [favorites]);
+
+  const isFavorite = (name: string) =>
+    favorites.some((f) => f.toLowerCase() === name.toLowerCase());
+
+  const toggleFavorite = (name: string) => {
+    setFavorites((prev) =>
+      isFavorite(name)
+        ? prev.filter((f) => f.toLowerCase() !== name.toLowerCase())
+        : [...prev, name],
+    );
+  };
+
+  return { favorites, isFavorite, toggleFavorite };
+}

--- a/src/hooks/useSearchHistory.ts
+++ b/src/hooks/useSearchHistory.ts
@@ -1,0 +1,38 @@
+import { useState } from "react";
+
+const STORAGE_KEY = "tfl-search-history";
+const MAX_ENTRIES = 8;
+
+export function useSearchHistory() {
+  const [history, setHistory] = useState<string[]>(() => {
+    try {
+      return JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "[]");
+    } catch {
+      return [];
+    }
+  });
+
+  const addToHistory = (name: string) => {
+    if (!name.trim()) return;
+    setHistory((prev) => {
+      const filtered = prev.filter(
+        (n) => n.toLowerCase() !== name.toLowerCase(),
+      );
+      const updated = [name, ...filtered].slice(0, MAX_ENTRIES);
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+      return updated;
+    });
+  };
+
+  const removeFromHistory = (name: string) => {
+    setHistory((prev) => {
+      const updated = prev.filter(
+        (n) => n.toLowerCase() !== name.toLowerCase(),
+      );
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+      return updated;
+    });
+  };
+
+  return { history, addToHistory, removeFromHistory };
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -11,14 +11,28 @@
 // Import Routes
 
 import { Route as rootRoute } from './routes/__root'
+import { Route as CompareImport } from './routes/compare'
 import { Route as IndexImport } from './routes/index'
+import { Route as PlayersPlayerNameImport } from './routes/players.$playerName'
 import { Route as ClubsClubTagImport } from './routes/clubs.$clubTag'
 
 // Create/Update Routes
 
+const CompareRoute = CompareImport.update({
+  id: '/compare',
+  path: '/compare',
+  getParentRoute: () => rootRoute,
+} as any)
+
 const IndexRoute = IndexImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRoute,
+} as any)
+
+const PlayersPlayerNameRoute = PlayersPlayerNameImport.update({
+  id: '/players/$playerName',
+  path: '/players/$playerName',
   getParentRoute: () => rootRoute,
 } as any)
 
@@ -39,11 +53,25 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexImport
       parentRoute: typeof rootRoute
     }
+    '/compare': {
+      id: '/compare'
+      path: '/compare'
+      fullPath: '/compare'
+      preLoaderRoute: typeof CompareImport
+      parentRoute: typeof rootRoute
+    }
     '/clubs/$clubTag': {
       id: '/clubs/$clubTag'
       path: '/clubs/$clubTag'
       fullPath: '/clubs/$clubTag'
       preLoaderRoute: typeof ClubsClubTagImport
+      parentRoute: typeof rootRoute
+    }
+    '/players/$playerName': {
+      id: '/players/$playerName'
+      path: '/players/$playerName'
+      fullPath: '/players/$playerName'
+      preLoaderRoute: typeof PlayersPlayerNameImport
       parentRoute: typeof rootRoute
     }
   }
@@ -53,37 +81,47 @@ declare module '@tanstack/react-router' {
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/compare': typeof CompareRoute
   '/clubs/$clubTag': typeof ClubsClubTagRoute
+  '/players/$playerName': typeof PlayersPlayerNameRoute
 }
 
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/compare': typeof CompareRoute
   '/clubs/$clubTag': typeof ClubsClubTagRoute
+  '/players/$playerName': typeof PlayersPlayerNameRoute
 }
 
 export interface FileRoutesById {
   __root__: typeof rootRoute
   '/': typeof IndexRoute
+  '/compare': typeof CompareRoute
   '/clubs/$clubTag': typeof ClubsClubTagRoute
+  '/players/$playerName': typeof PlayersPlayerNameRoute
 }
 
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/clubs/$clubTag'
+  fullPaths: '/' | '/compare' | '/clubs/$clubTag' | '/players/$playerName'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/clubs/$clubTag'
-  id: '__root__' | '/' | '/clubs/$clubTag'
+  to: '/' | '/compare' | '/clubs/$clubTag' | '/players/$playerName'
+  id: '__root__' | '/' | '/compare' | '/clubs/$clubTag' | '/players/$playerName'
   fileRoutesById: FileRoutesById
 }
 
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  CompareRoute: typeof CompareRoute
   ClubsClubTagRoute: typeof ClubsClubTagRoute
+  PlayersPlayerNameRoute: typeof PlayersPlayerNameRoute
 }
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  CompareRoute: CompareRoute,
   ClubsClubTagRoute: ClubsClubTagRoute,
+  PlayersPlayerNameRoute: PlayersPlayerNameRoute,
 }
 
 export const routeTree = rootRoute
@@ -97,14 +135,22 @@ export const routeTree = rootRoute
       "filePath": "__root.tsx",
       "children": [
         "/",
-        "/clubs/$clubTag"
+        "/compare",
+        "/clubs/$clubTag",
+        "/players/$playerName"
       ]
     },
     "/": {
       "filePath": "index.tsx"
     },
+    "/compare": {
+      "filePath": "compare.tsx"
+    },
     "/clubs/$clubTag": {
       "filePath": "clubs.$clubTag.tsx"
+    },
+    "/players/$playerName": {
+      "filePath": "players.$playerName.tsx"
     }
   }
 }

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,4 +1,6 @@
 import CommunityProgress from "@/components/CommunityProgress";
+import { CommandPalette } from "@/components/CommandPalette";
+import { KeyboardShortcutsDialog } from "@/components/KeyboardShortcutsDialog";
 import { BlueskyIcon, GitHubIcon, XTwitterIcon } from "@/components/icons";
 import BasicLink from "@/components/Link";
 import { Notice } from "@/components/Notice";
@@ -21,6 +23,10 @@ export const Route = createRootRoute({
 function RootComponent() {
   return (
     <ThemeProvider defaultTheme="light" storageKey="ui-theme">
+      <CommandPalette />
+      <div className="fixed bottom-4 right-4 z-40 font-saira">
+        <KeyboardShortcutsDialog />
+      </div>
       <div className="container mb-12 mt-2 font-saira max-sm:px-2">
         <h1 className="text-2xl font-medium sm:text-3xl">
           <Link to="/">Enhanced Leaderboard – THE FINALS</Link>

--- a/src/routes/clubs.$clubTag.tsx
+++ b/src/routes/clubs.$clubTag.tsx
@@ -15,9 +15,9 @@ function RouteComponent() {
   const { clubTag } = Route.useParams();
 
   useEffect(() => {
-    document.title = `[${clubTag}] · THE FINALS - Enhanced Leaderboard`;
+    document.title = `[${clubTag}] · Enhanced Leaderboard – THE FINALS`;
     return () => {
-      document.title = "THE FINALS - Enhanced Leaderboard";
+      document.title = "Enhanced Leaderboard – THE FINALS";
     };
   }, [clubTag]);
 

--- a/src/routes/clubs.$clubTag.tsx
+++ b/src/routes/clubs.$clubTag.tsx
@@ -15,9 +15,9 @@ function RouteComponent() {
   const { clubTag } = Route.useParams();
 
   useEffect(() => {
-    document.title = `[${clubTag}] · The Finals Leaderboard`;
+    document.title = `[${clubTag}] · THE FINALS - Enhanced Leaderboard`;
     return () => {
-      document.title = "The Finals Leaderboard";
+      document.title = "THE FINALS - Enhanced Leaderboard";
     };
   }, [clubTag]);
 

--- a/src/routes/clubs.$clubTag.tsx
+++ b/src/routes/clubs.$clubTag.tsx
@@ -3,8 +3,9 @@ import { panels } from "@/types";
 import { leaderboards } from "@/utils/leaderboards";
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { ArrowLeftIcon } from "lucide-react";
-import { ReactNode } from "react";
+import { AlertCircleIcon, ArrowLeftIcon } from "lucide-react";
+import { ReactNode, useEffect } from "react";
+import { Button } from "@/components/ui/button";
 
 export const Route = createFileRoute("/clubs/$clubTag")({
   component: RouteComponent,
@@ -13,6 +14,13 @@ export const Route = createFileRoute("/clubs/$clubTag")({
 function RouteComponent() {
   const { clubTag } = Route.useParams();
 
+  useEffect(() => {
+    document.title = `[${clubTag}] · The Finals Leaderboard`;
+    return () => {
+      document.title = "The Finals Leaderboard";
+    };
+  }, [clubTag]);
+
   const query = useQuery(clubsQueryOptions);
 
   if (query.isLoading) {
@@ -20,7 +28,22 @@ function RouteComponent() {
   }
 
   if (query.isError || !query.data) {
-    return <PageWrapper>An error happened :(</PageWrapper>;
+    return (
+      <PageWrapper>
+        <div className="flex flex-col items-start gap-3">
+          <div className="flex items-center gap-2 text-red-500">
+            <AlertCircleIcon className="size-5" />
+            <span className="font-medium">Failed to load club data</span>
+          </div>
+          <p className="text-sm text-neutral-500">
+            Something went wrong while fetching data. Please try again.
+          </p>
+          <Button variant="outline" size="sm" onClick={() => query.refetch()}>
+            Try again
+          </Button>
+        </div>
+      </PageWrapper>
+    );
   }
 
   const club = query.data.find(
@@ -94,8 +117,8 @@ function RouteComponent() {
               .map((member) => (
                 <Link
                   key={member.name}
-                  to="/"
-                  search={{ name: member.name }}
+                  to="/players/$playerName"
+                  params={{ playerName: member.name }}
                   className="mr-1 cursor-pointer rounded bg-neutral-200 px-1 transition-colors hover:bg-neutral-300 dark:bg-neutral-800 dark:hover:bg-neutral-700"
                 >
                   {member.name}

--- a/src/routes/compare.tsx
+++ b/src/routes/compare.tsx
@@ -74,11 +74,11 @@ function RouteComponent() {
   useEffect(() => {
     const title =
       player1 && player2
-        ? `${player1} vs ${player2} · THE FINALS - Enhanced Leaderboard`
-        : "Compare Players · THE FINALS - Enhanced Leaderboard";
+        ? `${player1} vs ${player2} · Enhanced Leaderboard – THE FINALS`
+        : "Compare Players · Enhanced Leaderboard – THE FINALS";
     document.title = title;
     return () => {
-      document.title = "THE FINALS - Enhanced Leaderboard";
+      document.title = "Enhanced Leaderboard – THE FINALS";
     };
   }, [player1, player2]);
 

--- a/src/routes/compare.tsx
+++ b/src/routes/compare.tsx
@@ -74,11 +74,11 @@ function RouteComponent() {
   useEffect(() => {
     const title =
       player1 && player2
-        ? `${player1} vs ${player2} · The Finals Leaderboard`
-        : "Compare Players · The Finals Leaderboard";
+        ? `${player1} vs ${player2} · THE FINALS - Enhanced Leaderboard`
+        : "Compare Players · THE FINALS - Enhanced Leaderboard";
     document.title = title;
     return () => {
-      document.title = "The Finals Leaderboard";
+      document.title = "THE FINALS - Enhanced Leaderboard";
     };
   }, [player1, player2]);
 

--- a/src/routes/compare.tsx
+++ b/src/routes/compare.tsx
@@ -275,7 +275,7 @@ function ComparisonRow({
           search={{ lb: lb.id as LeaderboardId, panel: panels.LEADERBOARD }}
           className="text-xs font-medium text-neutral-500 hover:underline"
         >
-          {lb.nameShort}
+          {lb.name}
         </Link>
       </td>
       <td className="px-4 py-3 text-right">

--- a/src/routes/compare.tsx
+++ b/src/routes/compare.tsx
@@ -1,0 +1,381 @@
+import { panels } from "@/types";
+import type { BaseUserWithExtras } from "@/types";
+import LeagueImage from "@/components/LeagueImage";
+import { SponsorImage } from "@/components/SponsorImage";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Leaderboard, LeaderboardId, leaderboards } from "@/utils/leaderboards";
+import { useQueries } from "@tanstack/react-query";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import {
+  ArrowLeftIcon,
+  ChevronDown,
+  ChevronUp,
+  Minus,
+  UserRoundIcon,
+} from "lucide-react";
+import { useEffect, useState } from "react";
+import { z } from "zod";
+
+const searchSchema = z.object({
+  players: z.string().array().optional(),
+});
+
+export const Route = createFileRoute("/compare")({
+  validateSearch: (search) => searchSchema.parse(search),
+  component: RouteComponent,
+});
+
+const allLeaderboards = Object.values(leaderboards).filter(
+  (lb) => lb.enabled,
+) as Leaderboard[];
+
+const getSeasonGroup = (id: string): string => {
+  if (id.startsWith("season9")) return "Season 9";
+  if (id.startsWith("season8")) return "Season 8";
+  if (id.startsWith("season7")) return "Season 7";
+  if (id.startsWith("season6")) return "Season 6";
+  if (id.startsWith("season5")) return "Season 5";
+  if (id.startsWith("season4")) return "Season 4";
+  if (id.startsWith("season3")) return "Season 3";
+  if (id.startsWith("season2")) return "Season 2";
+  if (id.startsWith("season1")) return "Season 1";
+  if (id.startsWith("openBeta")) return "Open Beta";
+  if (id.startsWith("closedBeta")) return "Closed Beta";
+  return "Other";
+};
+
+const seasonOrder = [
+  "Season 9",
+  "Season 8",
+  "Season 7",
+  "Season 6",
+  "Season 5",
+  "Season 4",
+  "Season 3",
+  "Season 2",
+  "Season 1",
+  "Open Beta",
+  "Closed Beta",
+  "Other",
+];
+
+function RouteComponent() {
+  const { players = [] } = Route.useSearch();
+  const navigate = useNavigate();
+  const [inputs, setInputs] = useState<[string, string]>([
+    players[0] ?? "",
+    players[1] ?? "",
+  ]);
+
+  const player1 = players[0];
+  const player2 = players[1];
+
+  useEffect(() => {
+    const title =
+      player1 && player2
+        ? `${player1} vs ${player2} · The Finals Leaderboard`
+        : "Compare Players · The Finals Leaderboard";
+    document.title = title;
+    return () => {
+      document.title = "The Finals Leaderboard";
+    };
+  }, [player1, player2]);
+
+  const queries = useQueries({
+    queries: allLeaderboards.map((lb) => ({
+      queryKey: ["leaderboard", lb.id],
+      queryFn: () => lb.fetchData("crossplay") as Promise<BaseUserWithExtras[]>,
+      staleTime: Infinity,
+    })),
+  });
+
+  const isLoading = queries.some((q) => q.isLoading);
+
+  const handleCompare = () => {
+    const trimmed = inputs.map((s) => s.trim()).filter(Boolean);
+    navigate({
+      to: "/compare",
+      search: { players: trimmed.length ? trimmed : undefined },
+    });
+  };
+
+  const getUser = (playerName: string, lbIndex: number) =>
+    (queries[lbIndex].data as BaseUserWithExtras[] | undefined)?.find(
+      (u) => u.name.toLowerCase() === playerName.toLowerCase(),
+    );
+
+  // Leaderboards where at least one player appears
+  const relevantLbs = player1
+    ? allLeaderboards.filter((_lb, i) => {
+        const u1 = getUser(player1, i);
+        const u2 = player2 ? getUser(player2, i) : undefined;
+        return u1 !== undefined || u2 !== undefined;
+      })
+    : [];
+
+  // Group by season
+  const grouped = new Map<string, typeof relevantLbs>();
+  for (const lb of relevantLbs) {
+    const group = getSeasonGroup(lb.id);
+    if (!grouped.has(group)) grouped.set(group, []);
+    grouped.get(group)!.push(lb);
+  }
+  const sortedGroups = [...grouped.entries()].sort(
+    ([a], [b]) => seasonOrder.indexOf(a) - seasonOrder.indexOf(b),
+  );
+
+  return (
+    <div className="my-4 flex flex-col gap-6">
+      <Link
+        to="/"
+        className="flex w-fit items-center gap-1 font-medium hover:underline"
+      >
+        <ArrowLeftIcon size={20} /> Back to leaderboards
+      </Link>
+
+      <div>
+        <div className="mb-4 text-2xl font-medium">Compare Players</div>
+
+        {/* Input row */}
+        <div className="flex flex-wrap items-end gap-2">
+          <div className="flex flex-col gap-1">
+            <label className="text-xs font-medium text-neutral-500">
+              Player 1
+            </label>
+            <Input
+              className="w-52"
+              placeholder="Name#1234"
+              value={inputs[0]}
+              onChange={(e) => setInputs([e.target.value, inputs[1]])}
+              onKeyDown={(e) => e.key === "Enter" && handleCompare()}
+            />
+          </div>
+          <span className="pb-[9px] text-sm font-medium text-neutral-400">
+            vs
+          </span>
+          <div className="flex flex-col gap-1">
+            <label className="text-xs font-medium text-neutral-500">
+              Player 2
+            </label>
+            <Input
+              className="w-52"
+              placeholder="Name#1234"
+              value={inputs[1]}
+              onChange={(e) => setInputs([inputs[0], e.target.value])}
+              onKeyDown={(e) => e.key === "Enter" && handleCompare()}
+            />
+          </div>
+          <Button onClick={handleCompare}>Compare</Button>
+        </div>
+      </div>
+
+      {/* Results */}
+      {player1 && player2 && (
+        <div className="flex flex-col gap-6">
+          {/* Player name headers */}
+          <div className="grid grid-cols-[1fr_1fr_1fr] items-center gap-4 border-b border-neutral-200 pb-3 dark:border-neutral-800">
+            <PlayerNameChip name={player1} />
+            <span className="text-center text-xs font-medium uppercase tracking-wider text-neutral-400">
+              Leaderboard
+            </span>
+            <div className="flex justify-end">
+              <PlayerNameChip name={player2} />
+            </div>
+          </div>
+
+          {isLoading && (
+            <p className="text-sm text-neutral-500">Loading data...</p>
+          )}
+
+          {!isLoading && sortedGroups.length === 0 && (
+            <p className="text-neutral-500">
+              Neither player was found in the top 10K of any leaderboard.
+            </p>
+          )}
+
+          {sortedGroups.map(([season, lbs]) => (
+            <div key={season}>
+              <div className="mb-2 text-xs font-semibold uppercase tracking-wider text-neutral-500">
+                {season}
+              </div>
+              <div className="overflow-hidden rounded-lg border border-neutral-200 dark:border-neutral-800">
+                <table className="w-full text-sm">
+                  <tbody>
+                    {lbs.map((lb, lbLocalIdx) => {
+                      const globalIdx = allLeaderboards.findIndex(
+                        (x) => x.id === lb.id,
+                      );
+                      const u1 = getUser(player1, globalIdx);
+                      const u2 = getUser(player2, globalIdx);
+                      return (
+                        <ComparisonRow
+                          key={lb.id}
+                          lb={lb}
+                          u1={u1}
+                          u2={u2}
+                          isLast={lbLocalIdx === lbs.length - 1}
+                        />
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Single player: show hint */}
+      {player1 && !player2 && !isLoading && (
+        <p className="text-sm text-neutral-500">
+          Enter a second player name above and click Compare.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function PlayerNameChip({ name }: { name: string }) {
+  const [base, tag] = name.split("#");
+  return (
+    <Link
+      to="/players/$playerName"
+      params={{ playerName: name }}
+      className="flex w-fit items-center gap-1.5 font-medium hover:underline"
+    >
+      <UserRoundIcon className="size-4 shrink-0 text-neutral-400" />
+      <span>{base}</span>
+      {tag && <span className="text-neutral-400">#{tag}</span>}
+    </Link>
+  );
+}
+
+function ComparisonRow({
+  lb,
+  u1,
+  u2,
+  isLast,
+}: {
+  lb: Leaderboard;
+  u1: BaseUserWithExtras | undefined;
+  u2: BaseUserWithExtras | undefined;
+  isLast: boolean;
+}) {
+  return (
+    <tr
+      className={`grid grid-cols-[1fr_auto_1fr] items-center ${!isLast ? "border-b border-neutral-200 dark:border-neutral-800" : ""}`}
+    >
+      <td className="px-4 py-3">
+        <PlayerStat user={u1} lb={lb} />
+      </td>
+      <td className="px-4 py-3 text-center">
+        <Link
+          to="/"
+          search={{ lb: lb.id as LeaderboardId, panel: panels.LEADERBOARD }}
+          className="text-xs font-medium text-neutral-500 hover:underline"
+        >
+          {lb.nameShort}
+        </Link>
+      </td>
+      <td className="px-4 py-3 text-right">
+        <PlayerStat user={u2} lb={lb} align="right" />
+      </td>
+    </tr>
+  );
+}
+
+function PlayerStat({
+  user,
+  lb,
+  align = "left",
+}: {
+  user: BaseUserWithExtras | undefined;
+  lb: Leaderboard;
+  align?: "left" | "right";
+}) {
+  const cols = lb.tableColumns;
+  const side = align === "right" ? "items-end" : "items-start";
+
+  if (!user)
+    return (
+      <div className={`flex flex-col ${side}`}>
+        <span className="text-sm text-neutral-400">—</span>
+      </div>
+    );
+
+  return (
+    <div className={`flex flex-col gap-0.5 ${side}`}>
+      <span className="font-semibold">#{user.rank.toLocaleString("en")}</span>
+
+      {cols.includes("change") && <RankChange change={user.change} />}
+
+      {cols.includes("fame") && user.league && (
+        <div className="flex items-center gap-1">
+          <LeagueImage league={user.league} size={14} />
+          <span className="text-xs text-neutral-500">{user.league}</span>
+        </div>
+      )}
+
+      {cols.includes("fame") &&
+        (user.fame !== undefined || user.rankScore !== undefined) && (
+          <span className="text-xs text-neutral-500">
+            {(user.fame ?? user.rankScore ?? 0).toLocaleString("en")}{" "}
+            {user.rankScore !== undefined ? "RS" : "fame"}
+          </span>
+        )}
+
+      {cols.includes("fans") && user.sponsor && (
+        <div className="flex items-center gap-1">
+          <SponsorImage sponsor={user.sponsor} size={14} useIcon />
+          <span className="text-xs text-neutral-500">
+            {(user.fans ?? 0).toLocaleString("en")} fans
+          </span>
+        </div>
+      )}
+
+      {!cols.includes("fame") &&
+        cols.includes("cashouts") &&
+        user.cashouts !== undefined && (
+          <span className="text-xs text-neutral-500">
+            {user.cashouts.toLocaleString("en", {
+              style: "currency",
+              currency: "USD",
+              maximumFractionDigits: 0,
+            })}
+          </span>
+        )}
+
+      {!cols.includes("fame") &&
+        !cols.includes("cashouts") &&
+        cols.includes("points") &&
+        user.points !== undefined && (
+          <span className="text-xs text-neutral-500">
+            {user.points.toLocaleString("en")} pts
+          </span>
+        )}
+    </div>
+  );
+}
+
+function RankChange({ change }: { change: number }) {
+  if (change > 0)
+    return (
+      <span className="inline-flex items-center text-xs text-indigo-400 dark:text-indigo-300">
+        <ChevronUp className="size-3" />
+        {change.toLocaleString("en")}
+      </span>
+    );
+  if (change < 0)
+    return (
+      <span className="inline-flex items-center text-xs text-red-500">
+        <ChevronDown className="size-3" />
+        {Math.abs(change).toLocaleString("en")}
+      </span>
+    );
+  return (
+    <span className="inline-flex items-center text-xs text-neutral-500">
+      <Minus className="size-3" />0
+    </span>
+  );
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -21,6 +21,12 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
+import { useFavorites } from "@/hooks/useFavorites";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { LeaderboardFeature, panels, platforms } from "@/types";
 import { fetchData } from "@/utils/fetchData";
 import {
@@ -31,14 +37,18 @@ import {
   leaderboards,
 } from "@/utils/leaderboards";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { createFileRoute } from "@tanstack/react-router";
+import { HOUR, MINUTE } from "@/utils/time";
+import { createFileRoute, Link } from "@tanstack/react-router";
 import { ColumnDef } from "@tanstack/react-table";
 import {
   BarChartIcon,
   HomeIcon,
   Loader2Icon,
   RefreshCwIcon,
+  StarIcon,
   TrophyIcon,
+  UserRoundIcon,
+  XIcon,
 } from "lucide-react";
 import { useEffect } from "react";
 import { z } from "zod";
@@ -78,11 +88,19 @@ function RouteComponent() {
   });
   const navigate = Route.useNavigate();
   const queryClient = useQueryClient();
+  const { favorites, toggleFavorite } = useFavorites();
 
   // This is safe because lbParam is validated above
   const leaderboard = Object.values(leaderboards).find(
     (x) => x.id === lbParam,
   )!;
+
+  useEffect(() => {
+    document.title = `${leaderboard.name} · The Finals Leaderboard`;
+    return () => {
+      document.title = "The Finals Leaderboard";
+    };
+  }, [leaderboard.name]);
 
   // Use TanStack Query to fetch data
   // This will cache all combinations of leaderboard version and platform infinitely
@@ -313,6 +331,57 @@ function RouteComponent() {
           </Tabs>
         )}
 
+        {/* Favorites popover */}
+        <Popover>
+          <PopoverTrigger asChild>
+            <Button variant="outline" className="select-none gap-1.5">
+              <StarIcon className="size-4" />
+              <span className="hidden min-[400px]:block">Favorites</span>
+              {favorites.length > 0 && (
+                <span className="rounded-full bg-neutral-200 px-1.5 py-0.5 text-xs font-medium leading-none dark:bg-neutral-700">
+                  {favorites.length}
+                </span>
+              )}
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent align="end" className="w-64 p-2 font-saira">
+            {favorites.length === 0 ? (
+              <p className="px-2 py-1.5 text-sm text-neutral-500">
+                No favorites yet. Open a player profile and click{" "}
+                <StarIcon className="inline size-3" /> to save them here.
+              </p>
+            ) : (
+              <div className="flex flex-col gap-0.5">
+                <p className="px-2 py-1 text-xs font-semibold uppercase tracking-wider text-neutral-500">
+                  Saved Players
+                </p>
+                {favorites.map((name) => (
+                  <div
+                    key={name}
+                    className="flex items-center justify-between gap-1 rounded px-2 py-1.5 hover:bg-neutral-100 dark:hover:bg-neutral-800"
+                  >
+                    <Link
+                      to="/players/$playerName"
+                      params={{ playerName: name }}
+                      className="flex min-w-0 flex-1 items-center gap-1.5 text-sm"
+                    >
+                      <UserRoundIcon className="size-3.5 shrink-0 text-neutral-400" />
+                      <span className="truncate">{name}</span>
+                    </Link>
+                    <button
+                      onClick={() => toggleFavorite(name)}
+                      className="shrink-0 text-neutral-400 hover:text-red-500"
+                      title="Remove"
+                    >
+                      <XIcon className="size-3.5" />
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </PopoverContent>
+        </Popover>
+
         <TooltipProvider disableHoverableContent>
           <Tooltip>
             <TooltipTrigger asChild>
@@ -358,10 +427,13 @@ function RouteComponent() {
           );
 
           return (
-            <div>
-              <div className="text-lg">
+            <div className="flex flex-col items-start gap-3">
+              <span className="text-lg font-medium text-red-500">
+                Failed to load data
+              </span>
+              <p className="text-neutral-600 dark:text-neutral-400">
                 An error happened. Please contact the developer on{" "}
-                <BasicLink href="https://x.com/mozzyfx">Twitter</BasicLink>,
+                <BasicLink href="https://x.com/mozzyfx">Twitter</BasicLink>,{" "}
                 <BasicLink href="https://bsky.app/profile/leon.ms">
                   Bluesky
                 </BasicLink>{" "}
@@ -370,17 +442,27 @@ function RouteComponent() {
                   file an issue on GitHub
                 </BasicLink>{" "}
                 if this error persists.
-              </div>
-
+              </p>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() =>
+                  queryClient.invalidateQueries({
+                    predicate: (query) => query.queryKey[0] !== "notice",
+                  })
+                }
+              >
+                Try again
+              </Button>
               {error && (
-                <div className="mt-3">
-                  <div className="font-medium">
-                    Useful information to include:
-                  </div>
-                  <pre className="overflow-x-auto rounded bg-neutral-100 p-2 dark:bg-neutral-900">
+                <details className="w-full">
+                  <summary className="cursor-pointer text-sm font-medium text-neutral-500">
+                    Error details
+                  </summary>
+                  <pre className="mt-2 overflow-x-auto rounded bg-neutral-100 p-2 text-xs dark:bg-neutral-900">
                     {error.stack}
                   </pre>
-                </div>
+                </details>
               )}
             </div>
           );
@@ -472,15 +554,32 @@ function RouteComponent() {
         </div>
       )}
 
-      <div className="mt-10">
-        <span>
-          Current data updated at{" "}
-          {loadingOrRefetching ? (
-            <Loader2Icon className="inline size-5 animate-spin" />
-          ) : (
-            new Date(dataUpdatedAt).toLocaleString()
-          )}
-        </span>
+      <div className="mt-10 flex items-center gap-2 text-sm text-neutral-500">
+        {loadingOrRefetching ? (
+          <>
+            <Loader2Icon className="size-4 animate-spin" />
+            <span>Updating...</span>
+          </>
+        ) : isError ? (
+          <>
+            <span className="size-2 rounded-full bg-red-500" />
+            <span>Error loading data</span>
+          </>
+        ) : (
+          <>
+            <span className="size-2 rounded-full bg-green-500" />
+            <span>
+              Live · Updated{" "}
+              {dataUpdatedAt === 0
+                ? "never"
+                : Date.now() - dataUpdatedAt < MINUTE
+                  ? "just now"
+                  : Date.now() - dataUpdatedAt < HOUR
+                    ? `${Math.floor((Date.now() - dataUpdatedAt) / MINUTE)}m ago`
+                    : `${Math.floor((Date.now() - dataUpdatedAt) / HOUR)}h ago`}
+            </span>
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -96,9 +96,9 @@ function RouteComponent() {
   )!;
 
   useEffect(() => {
-    document.title = `${leaderboard.name} · The Finals Leaderboard`;
+    document.title = `${leaderboard.name} · THE FINALS - Enhanced Leaderboard`;
     return () => {
-      document.title = "The Finals Leaderboard";
+      document.title = "THE FINALS - Enhanced Leaderboard";
     };
   }, [leaderboard.name]);
 

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -96,9 +96,9 @@ function RouteComponent() {
   )!;
 
   useEffect(() => {
-    document.title = `${leaderboard.name} · THE FINALS - Enhanced Leaderboard`;
+    document.title = `${leaderboard.name} · Enhanced Leaderboard – THE FINALS`;
     return () => {
-      document.title = "THE FINALS - Enhanced Leaderboard";
+      document.title = "Enhanced Leaderboard – THE FINALS";
     };
   }, [leaderboard.name]);
 

--- a/src/routes/players.$playerName.tsx
+++ b/src/routes/players.$playerName.tsx
@@ -144,8 +144,9 @@ function RouteComponent() {
         (u) => u.name.toLowerCase() === playerName.toLowerCase(),
       ),
     }))
-    .filter((e): e is { lb: Leaderboard; user: BaseUserWithExtras } =>
-      e.user !== undefined,
+    .filter(
+      (e): e is { lb: Leaderboard; user: BaseUserWithExtras } =>
+        e.user !== undefined,
     );
 
   const baseUser = playerEntries[0]?.user;
@@ -156,7 +157,9 @@ function RouteComponent() {
       <PageWrapper playerName={playerName}>
         <div className="flex flex-col gap-4">
           <div>
-            <div className="mb-1 text-2xl font-medium break-all">{playerName}</div>
+            <div className="mb-1 break-all text-2xl font-medium">
+              {playerName}
+            </div>
             <p className="text-neutral-500">
               This player wasn't found in the top 10,000 of any leaderboard.
             </p>
@@ -245,10 +248,7 @@ function RouteComponent() {
           {/* Action buttons */}
           <div className="flex shrink-0 items-center gap-2">
             <Button variant="outline" size="sm" className="gap-1.5" asChild>
-              <Link
-                to="/compare"
-                search={{ players: [playerName] }}
-              >
+              <Link to="/compare" search={{ players: [playerName] }}>
                 <GitCompareArrowsIcon className="size-4" />
                 <span className="hidden sm:inline">Compare</span>
               </Link>
@@ -431,12 +431,12 @@ function StatCard({
       {cols.includes("change") && (
         <div>
           {user.change > 0 ? (
-            <span className="animate-in slide-in-from-bottom-1 inline-flex items-center text-sm text-indigo-400 dark:text-indigo-300">
+            <span className="inline-flex items-center text-sm text-indigo-400 animate-in slide-in-from-bottom-1 dark:text-indigo-300">
               <ChevronUp className="h-4" />
               {user.change.toLocaleString("en")}
             </span>
           ) : user.change < 0 ? (
-            <span className="animate-in slide-in-from-top-1 inline-flex items-center text-sm text-red-500">
+            <span className="inline-flex items-center text-sm text-red-500 animate-in slide-in-from-top-1">
               <ChevronDown className="h-4" />
               {Math.abs(user.change).toLocaleString("en")}
             </span>

--- a/src/routes/players.$playerName.tsx
+++ b/src/routes/players.$playerName.tsx
@@ -73,9 +73,9 @@ function RouteComponent() {
   const queryClient = useQueryClient();
 
   useEffect(() => {
-    document.title = `${playerName} · THE FINALS - Enhanced Leaderboard`;
+    document.title = `${playerName} · Enhanced Leaderboard – THE FINALS`;
     return () => {
-      document.title = "THE FINALS - Enhanced Leaderboard";
+      document.title = "Enhanced Leaderboard – THE FINALS";
     };
   }, [playerName]);
 

--- a/src/routes/players.$playerName.tsx
+++ b/src/routes/players.$playerName.tsx
@@ -419,9 +419,7 @@ function StatCard({
     >
       {/* Leaderboard name + rank */}
       <div className="flex items-center justify-between gap-2">
-        <span className="text-sm font-medium text-neutral-500">
-          {lb.name}
-        </span>
+        <span className="text-sm font-medium text-neutral-500">{lb.name}</span>
         <span className="text-lg font-semibold">
           #{user.rank.toLocaleString("en")}
         </span>

--- a/src/routes/players.$playerName.tsx
+++ b/src/routes/players.$playerName.tsx
@@ -73,9 +73,9 @@ function RouteComponent() {
   const queryClient = useQueryClient();
 
   useEffect(() => {
-    document.title = `${playerName} · The Finals Leaderboard`;
+    document.title = `${playerName} · THE FINALS - Enhanced Leaderboard`;
     return () => {
-      document.title = "The Finals Leaderboard";
+      document.title = "THE FINALS - Enhanced Leaderboard";
     };
   }, [playerName]);
 

--- a/src/routes/players.$playerName.tsx
+++ b/src/routes/players.$playerName.tsx
@@ -420,7 +420,7 @@ function StatCard({
       {/* Leaderboard name + rank */}
       <div className="flex items-center justify-between gap-2">
         <span className="text-sm font-medium text-neutral-500">
-          {lb.nameShort}
+          {lb.name}
         </span>
         <span className="text-lg font-semibold">
           #{user.rank.toLocaleString("en")}

--- a/src/routes/players.$playerName.tsx
+++ b/src/routes/players.$playerName.tsx
@@ -1,0 +1,520 @@
+import { panels } from "@/types";
+import type { BaseUserWithExtras } from "@/types";
+import LeagueImage from "@/components/LeagueImage";
+import { SponsorImage } from "@/components/SponsorImage";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { Button } from "@/components/ui/button";
+import { useFavorites } from "@/hooks/useFavorites";
+import { Leaderboard, LeaderboardId, leaderboards } from "@/utils/leaderboards";
+import { useQueries } from "@tanstack/react-query";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import {
+  AlertCircleIcon,
+  ArrowLeftIcon,
+  CheckIcon,
+  ChevronDown,
+  ChevronUp,
+  GitCompareArrowsIcon,
+  History,
+  Link2Icon,
+  Minus,
+  StarIcon,
+} from "lucide-react";
+import { useQueryClient } from "@tanstack/react-query";
+import { ReactNode, useEffect, useState } from "react";
+
+export const Route = createFileRoute("/players/$playerName")({
+  component: RouteComponent,
+});
+
+const allLeaderboards = Object.values(leaderboards).filter(
+  (lb) => lb.enabled,
+) as Leaderboard[];
+
+const getSeasonGroup = (id: string): string => {
+  if (id.startsWith("season9")) return "Season 9";
+  if (id.startsWith("season8")) return "Season 8";
+  if (id.startsWith("season7")) return "Season 7";
+  if (id.startsWith("season6")) return "Season 6";
+  if (id.startsWith("season5")) return "Season 5";
+  if (id.startsWith("season4")) return "Season 4";
+  if (id.startsWith("season3")) return "Season 3";
+  if (id.startsWith("season2")) return "Season 2";
+  if (id.startsWith("season1")) return "Season 1";
+  if (id.startsWith("openBeta")) return "Open Beta";
+  if (id.startsWith("closedBeta")) return "Closed Beta";
+  return "Other";
+};
+
+const seasonOrder = [
+  "Season 9",
+  "Season 8",
+  "Season 7",
+  "Season 6",
+  "Season 5",
+  "Season 4",
+  "Season 3",
+  "Season 2",
+  "Season 1",
+  "Open Beta",
+  "Closed Beta",
+  "Other",
+];
+
+function RouteComponent() {
+  const { playerName } = Route.useParams();
+  const { isFavorite, toggleFavorite } = useFavorites();
+  const [copied, setCopied] = useState(false);
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    document.title = `${playerName} · The Finals Leaderboard`;
+    return () => {
+      document.title = "The Finals Leaderboard";
+    };
+  }, [playerName]);
+
+  const queries = useQueries({
+    queries: allLeaderboards.map((lb) => ({
+      queryKey: ["leaderboard", lb.id],
+      queryFn: () => lb.fetchData("crossplay") as Promise<BaseUserWithExtras[]>,
+      staleTime: Infinity,
+    })),
+  });
+
+  const isAllLoading = queries.every((q) => q.isLoading);
+  const isAllError = queries.every((q) => q.isError);
+  const someLoading = queries.some((q) => q.isLoading);
+
+  const handleShare = () => {
+    navigator.clipboard.writeText(window.location.href).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  if (isAllLoading) {
+    return (
+      <PageWrapper playerName={playerName}>
+        <PlayerHeader />
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <SkeletonCard key={i} />
+          ))}
+        </div>
+      </PageWrapper>
+    );
+  }
+
+  if (isAllError) {
+    return (
+      <PageWrapper playerName={playerName}>
+        <div className="flex flex-col items-start gap-3">
+          <div className="flex items-center gap-2 text-red-500">
+            <AlertCircleIcon className="size-5" />
+            <span className="font-medium">Failed to load player data</span>
+          </div>
+          <p className="text-sm text-neutral-500">
+            Something went wrong while fetching leaderboard data. Please try
+            again.
+          </p>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() =>
+              queryClient.invalidateQueries({ queryKey: ["leaderboard"] })
+            }
+          >
+            Try again
+          </Button>
+        </div>
+      </PageWrapper>
+    );
+  }
+
+  const playerEntries = allLeaderboards
+    .map((lb, i) => ({
+      lb,
+      user: (queries[i].data as BaseUserWithExtras[] | undefined)?.find(
+        (u) => u.name.toLowerCase() === playerName.toLowerCase(),
+      ),
+    }))
+    .filter((e): e is { lb: Leaderboard; user: BaseUserWithExtras } =>
+      e.user !== undefined,
+    );
+
+  const baseUser = playerEntries[0]?.user;
+  const favorited = isFavorite(playerName);
+
+  if (playerEntries.length === 0 && !someLoading) {
+    return (
+      <PageWrapper playerName={playerName}>
+        <div className="flex flex-col gap-4">
+          <div>
+            <div className="mb-1 text-2xl font-medium break-all">{playerName}</div>
+            <p className="text-neutral-500">
+              This player wasn't found in the top 10,000 of any leaderboard.
+            </p>
+          </div>
+          <div className="rounded-lg border border-neutral-200 p-4 dark:border-neutral-800">
+            <p className="mb-2 text-sm font-medium text-neutral-600 dark:text-neutral-400">
+              Suggestions:
+            </p>
+            <ul className="flex flex-col gap-1.5 text-sm text-neutral-500">
+              <li>• Check the spelling — names are case-insensitive</li>
+              <li>
+                • Make sure the full name is included, e.g.{" "}
+                <span className="font-mono text-xs">Name#1234</span>
+              </li>
+              <li>• The player may not be in the top 10K on any leaderboard</li>
+            </ul>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button variant="outline" size="sm" asChild>
+              <Link to="/" search={{ name: playerName }}>
+                Search on main leaderboard
+              </Link>
+            </Button>
+          </div>
+        </div>
+      </PageWrapper>
+    );
+  }
+
+  const grouped = new Map<string, typeof playerEntries>();
+  for (const entry of playerEntries) {
+    const group = getSeasonGroup(entry.lb.id);
+    if (!grouped.has(group)) grouped.set(group, []);
+    grouped.get(group)!.push(entry);
+  }
+
+  const sortedGroups = Array.from(grouped.entries()).sort(
+    ([a], [b]) => seasonOrder.indexOf(a) - seasonOrder.indexOf(b),
+  );
+
+  return (
+    <PageWrapper playerName={playerName}>
+      <div className="flex flex-col gap-6">
+        {/* Header */}
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0">
+            <div className="truncate text-3xl font-medium sm:text-4xl">
+              <span>{playerName.split("#")[0]}</span>
+              <span className="text-neutral-500">
+                #{playerName.split("#")[1]}
+              </span>
+            </div>
+            <div className="mt-1 flex flex-wrap items-center gap-2 text-sm">
+              {baseUser?.clubTag && (
+                <Link
+                  to="/clubs/$clubTag"
+                  params={{ clubTag: baseUser.clubTag }}
+                  className="rounded bg-neutral-200 px-1.5 py-0.5 font-medium transition-colors hover:bg-neutral-300 dark:bg-neutral-800 dark:hover:bg-neutral-700"
+                >
+                  [{baseUser.clubTag}]
+                </Link>
+              )}
+              {baseUser?.steamName && (
+                <span className="text-neutral-500">
+                  Steam: {baseUser.steamName}
+                </span>
+              )}
+              {baseUser?.xboxName && (
+                <span className="text-neutral-500">
+                  Xbox: {baseUser.xboxName}
+                </span>
+              )}
+              {baseUser?.psnName && (
+                <span className="text-neutral-500">
+                  PSN: {baseUser.psnName}
+                </span>
+              )}
+            </div>
+            {someLoading && (
+              <div className="mt-1 text-sm text-neutral-500">
+                Loading more leaderboards...
+              </div>
+            )}
+          </div>
+
+          {/* Action buttons */}
+          <div className="flex shrink-0 items-center gap-2">
+            <Button variant="outline" size="sm" className="gap-1.5" asChild>
+              <Link
+                to="/compare"
+                search={{ players: [playerName] }}
+              >
+                <GitCompareArrowsIcon className="size-4" />
+                <span className="hidden sm:inline">Compare</span>
+              </Link>
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleShare}
+              className="gap-1.5"
+            >
+              {copied ? (
+                <>
+                  <CheckIcon className="size-4 text-green-500" />
+                  <span className="hidden sm:inline">Copied!</span>
+                </>
+              ) : (
+                <>
+                  <Link2Icon className="size-4" />
+                  <span className="hidden sm:inline">Share</span>
+                </>
+              )}
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => toggleFavorite(playerName)}
+              className="gap-1.5"
+              title={favorited ? "Remove from favorites" : "Add to favorites"}
+            >
+              <StarIcon
+                className={`size-4 transition-colors ${favorited ? "fill-yellow-400 text-yellow-400" : ""}`}
+              />
+              <span className="hidden sm:inline">
+                {favorited ? "Saved" : "Favorite"}
+              </span>
+            </Button>
+          </div>
+        </div>
+
+        {/* Current season — always visible */}
+        {sortedGroups
+          .filter(([season]) => season === "Season 9")
+          .map(([season, entries]) => (
+            <SeasonSection
+              key={season}
+              season={season}
+              entries={entries}
+              playerName={playerName}
+            />
+          ))}
+
+        {/* Older seasons — collapsible accordion */}
+        {sortedGroups.some(([season]) => season !== "Season 9") && (
+          <div className="rounded-lg border border-neutral-200 px-4 dark:border-neutral-800">
+            <div className="flex items-center gap-2 py-3">
+              <History className="size-4 text-neutral-500" />
+              <span className="text-sm font-semibold text-neutral-500">
+                Previous Seasons
+              </span>
+              <span className="rounded-full bg-neutral-200 px-2 py-0.5 text-xs font-medium text-neutral-600 dark:bg-neutral-800 dark:text-neutral-400">
+                {sortedGroups
+                  .filter(([s]) => s !== "Season 9")
+                  .reduce((acc, [, e]) => acc + e.length, 0)}{" "}
+                leaderboards
+              </span>
+            </div>
+            <Accordion type="multiple" className="w-full">
+              {sortedGroups
+                .filter(([season]) => season !== "Season 9")
+                .map(([season, entries]) => (
+                  <AccordionItem key={season} value={season}>
+                    <AccordionTrigger className="text-sm font-medium hover:no-underline">
+                      <span className="flex items-center gap-2">
+                        {season}
+                        <span className="rounded-full bg-neutral-200 px-2 py-0.5 text-xs font-normal text-neutral-500 dark:bg-neutral-800">
+                          {entries.length}
+                        </span>
+                      </span>
+                    </AccordionTrigger>
+                    <AccordionContent>
+                      <SeasonSection
+                        season={season}
+                        entries={entries}
+                        playerName={playerName}
+                      />
+                    </AccordionContent>
+                  </AccordionItem>
+                ))}
+            </Accordion>
+          </div>
+        )}
+      </div>
+    </PageWrapper>
+  );
+}
+
+function PlayerHeader() {
+  return (
+    <div className="mb-4">
+      <div className="h-9 w-48 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800 sm:h-10 sm:w-64" />
+      <div className="mt-2 h-4 w-32 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800" />
+    </div>
+  );
+}
+
+function SkeletonCard() {
+  return (
+    <div className="flex animate-pulse flex-col gap-2 rounded-lg border border-neutral-200 p-3 dark:border-neutral-800">
+      <div className="flex items-center justify-between">
+        <div className="h-4 w-10 rounded bg-neutral-200 dark:bg-neutral-700" />
+        <div className="h-6 w-14 rounded bg-neutral-200 dark:bg-neutral-700" />
+      </div>
+      <div className="h-4 w-16 rounded bg-neutral-200 dark:bg-neutral-700" />
+      <div className="flex items-center gap-2">
+        <div className="size-8 rounded bg-neutral-200 dark:bg-neutral-700" />
+        <div className="h-4 w-20 rounded bg-neutral-200 dark:bg-neutral-700" />
+      </div>
+      <div className="h-4 w-24 rounded bg-neutral-200 dark:bg-neutral-700" />
+    </div>
+  );
+}
+
+function SeasonSection({
+  season,
+  entries,
+  playerName,
+}: {
+  season: string;
+  entries: { lb: Leaderboard; user: BaseUserWithExtras }[];
+  playerName: string;
+}) {
+  return (
+    <div>
+      {season !== "Season 9" && (
+        <div className="mb-2 text-xs font-semibold uppercase tracking-wider text-neutral-500">
+          {season}
+        </div>
+      )}
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        {entries.map(({ lb, user }) => (
+          <StatCard key={lb.id} lb={lb} user={user} playerName={playerName} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function StatCard({
+  lb,
+  user,
+  playerName,
+}: {
+  lb: Leaderboard;
+  user: BaseUserWithExtras;
+  playerName: string;
+}) {
+  const cols = lb.tableColumns;
+
+  return (
+    <Link
+      to="/"
+      search={{
+        lb: lb.id as LeaderboardId,
+        name: playerName,
+        panel: panels.LEADERBOARD,
+      }}
+      className="flex flex-col gap-2 rounded-lg border border-neutral-200 p-3 transition-colors hover:border-neutral-300 hover:bg-neutral-50 dark:border-neutral-800 dark:hover:border-neutral-700 dark:hover:bg-neutral-900"
+    >
+      {/* Leaderboard name + rank */}
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-sm font-medium text-neutral-500">
+          {lb.nameShort}
+        </span>
+        <span className="text-lg font-semibold">
+          #{user.rank.toLocaleString("en")}
+        </span>
+      </div>
+
+      {/* Rank change */}
+      {cols.includes("change") && (
+        <div>
+          {user.change > 0 ? (
+            <span className="animate-in slide-in-from-bottom-1 inline-flex items-center text-sm text-indigo-400 dark:text-indigo-300">
+              <ChevronUp className="h-4" />
+              {user.change.toLocaleString("en")}
+            </span>
+          ) : user.change < 0 ? (
+            <span className="animate-in slide-in-from-top-1 inline-flex items-center text-sm text-red-500">
+              <ChevronDown className="h-4" />
+              {Math.abs(user.change).toLocaleString("en")}
+            </span>
+          ) : (
+            <span className="inline-flex items-center text-sm text-neutral-500">
+              <Minus className="h-4" />
+              {user.change.toLocaleString("en")}
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* League badge */}
+      {user.league && cols.includes("fame") && (
+        <div className="flex items-center gap-2">
+          <LeagueImage league={user.league} size={32} />
+          <span className="text-sm">{user.league}</span>
+        </div>
+      )}
+
+      {/* Key stat */}
+      <div className="text-sm text-neutral-600 dark:text-neutral-400">
+        {cols.includes("fans") && user.sponsor && (
+          <div className="flex flex-col gap-1">
+            <SponsorImage sponsor={user.sponsor} size={60} useIcon />
+            <span>{(user.fans ?? 0).toLocaleString("en")} fans</span>
+          </div>
+        )}
+        {cols.includes("fame") &&
+          (user.fame !== undefined || user.rankScore !== undefined) && (
+            <span>
+              {(user.fame ?? user.rankScore ?? 0).toLocaleString("en")}{" "}
+              {user.rankScore !== undefined ? "rank score" : "fame"}
+            </span>
+          )}
+        {!cols.includes("fame") &&
+          cols.includes("cashouts") &&
+          user.cashouts !== undefined && (
+            <span>
+              {user.cashouts.toLocaleString("en", {
+                style: "currency",
+                currency: "USD",
+                maximumFractionDigits: 0,
+              })}
+            </span>
+          )}
+        {!cols.includes("fame") &&
+          !cols.includes("cashouts") &&
+          cols.includes("points") &&
+          user.points !== undefined && (
+            <span>{user.points.toLocaleString("en")} pts</span>
+          )}
+        {cols.includes("score") && user.score !== undefined && (
+          <span>{user.score.toLocaleString("en")} score</span>
+        )}
+        {cols.includes("distance") && user.distance !== undefined && (
+          <span>{user.distance.toFixed(2)} km</span>
+        )}
+      </div>
+    </Link>
+  );
+}
+
+const PageWrapper = ({
+  children,
+  playerName,
+}: {
+  children: ReactNode;
+  playerName: string;
+}) => (
+  <div className="my-4">
+    <Link
+      to="/"
+      search={{ name: playerName }}
+      className="mb-4 flex w-fit items-center gap-1 font-medium hover:underline"
+    >
+      <ArrowLeftIcon size={20} /> Back to leaderboards
+    </Link>
+    {children}
+  </div>
+);


### PR DESCRIPTION
## New pages & routes
- `/players/$playerName` — full player profile with stats across all leaderboards,
  grouped by season with collapsible accordion for previous seasons
- `/compare` — side-by-side player comparison across all leaderboards,
  grouped by season; accessible via "Compare" button on player profiles

## New features
- **⌘K Command palette** — global player search available from any page;
  searches main leaderboard (partial match) or opens profile directly
- **Search history** — last 8 searches saved to localStorage, shown as
  dropdown in the name filter input and in the command palette
- **Favorites** — star players on their profile page; quick-access popover
  on the main page
- **Share button** — copies player profile URL to clipboard
- **Export CSV** — downloads current filtered leaderboard table as CSV
- **Keyboard shortcuts** — floating `?` button (bottom-right) shows all hotkeys;
  `⌘K`, `/`, `← →` arrow key pagination now actually implemented
- **Player counter** — shows total players and filtered count in pagination

## UX improvements
- Skeleton loaders on main table and player profile
- Rank change animations (slide-in from bottom/top)
- Clickable player names in table → profile page
- Club member links → profile page
- Better error states on all pages (icon + message + retry button)
- Dynamic `document.title` on every page
- API status indicator (live / updating / error) in main page footer
- Better "not found" state on player profile with suggestions
![Screenshot 2026-02-27 at 13 21 04](https://github.com/user-attachments/assets/b75987d6-29bf-4bad-b4d8-6b3f14903102)
![Screenshot 2026-02-27 at 13 21 15](https://github.com/user-attachments/assets/92f527ec-711f-4da9-8690-c157e92eca64)
![Screenshot 2026-02-27 at 13 21 21](https://github.com/user-attachments/assets/a95eaf78-7371-4a75-8c61-c27ccfc4bbf3)
![Screenshot 2026-02-27 at 13 21 25](https://github.com/user-attachments/assets/289463a4-317c-4ed9-8a5b-19623292d829)
![Screenshot 2026-02-27 at 13 21 30](https://github.com/user-attachments/assets/17c77305-94a4-4b32-88b6-cee79a5791ec)
![Screenshot 2026-02-27 at 13 21 37](https://github.com/user-attachments/assets/5f04360d-a032-4f23-b75d-b10456fa5d14)
![Screenshot 2026-02-27 at 13 21 41](https://github.com/user-attachments/assets/dff6784b-da68-4310-8e05-3247a68fd9a2)
![Screenshot 2026-02-27 at 13 21 45](https://github.com/user-attachments/assets/893865e9-92f1-4b9f-b501-a698d12b6fde)
![Screenshot 2026-02-27 at 13 22 11](https://github.com/user-attachments/assets/8ce9bc7c-8935-4f81-9020-0069045a6adb)
