### PR TITLE
fix: strip spaces from search inputs and clear input on ESC

### DIFF
--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -26,20 +26,20 @@ export function CommandPalette() {
 
   // Search on main leaderboard page — partial match, like the main filter
   const handleSearch = (name: string) => {
-    const trimmed = name.trim();
-    if (!trimmed) return;
-    addToHistory(trimmed);
-    navigate({ to: "/", search: { name: trimmed } });
+    const cleaned = name.replace(/\s/g, "");
+    if (!cleaned) return;
+    addToHistory(cleaned);
+    navigate({ to: "/", search: { name: cleaned } });
     setOpen(false);
     setQuery("");
   };
 
   // Navigate directly to player profile — requires exact name (e.g. Name#1234)
   const handleProfile = (name: string) => {
-    const trimmed = name.trim();
-    if (!trimmed) return;
-    addToHistory(trimmed);
-    navigate({ to: "/players/$playerName", params: { playerName: trimmed } });
+    const cleaned = name.replace(/\s/g, "");
+    if (!cleaned) return;
+    addToHistory(cleaned);
+    navigate({ to: "/players/$playerName", params: { playerName: cleaned } });
     setOpen(false);
     setQuery("");
   };
@@ -51,8 +51,8 @@ export function CommandPalette() {
         value={query}
         onValueChange={setQuery}
         onKeyDown={(e) => {
-          if (e.key === "Enter" && query.trim()) {
-            handleSearch(query.trim());
+          if (e.key === "Enter" && query.replace(/\s/g, "")) {
+            handleSearch(query);
           }
         }}
       />

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -26,7 +26,7 @@ export function CommandPalette() {
 
   // Search on main leaderboard page — partial match, like the main filter
   const handleSearch = (name: string) => {
-    const cleaned = name.replace(/\s/g, "");
+    const cleaned = name.replace(/\s*#\s*/g, "#");
     if (!cleaned) return;
     addToHistory(cleaned);
     navigate({ to: "/", search: { name: cleaned } });
@@ -36,7 +36,7 @@ export function CommandPalette() {
 
   // Navigate directly to player profile — requires exact name (e.g. Name#1234)
   const handleProfile = (name: string) => {
-    const cleaned = name.replace(/\s/g, "");
+    const cleaned = name.replace(/\s*#\s*/g, "#");
     if (!cleaned) return;
     addToHistory(cleaned);
     navigate({ to: "/players/$playerName", params: { playerName: cleaned } });
@@ -51,7 +51,7 @@ export function CommandPalette() {
         value={query}
         onValueChange={setQuery}
         onKeyDown={(e) => {
-          if (e.key === "Enter" && query.replace(/\s/g, "")) {
+          if (e.key === "Enter" && query.replace(/\s*#\s*/g, "#").trim()) {
             handleSearch(query);
           }
         }}

--- a/src/components/tables/LeaderboardDataTableToolbar.tsx
+++ b/src/components/tables/LeaderboardDataTableToolbar.tsx
@@ -53,7 +53,7 @@ export function LeaderboardDataTableToolbar<TData>({
   );
 
   const handleSelectHistory = (selectedName: string) => {
-    const cleaned = selectedName.replace(/\s/g, "");
+    const cleaned = selectedName.replace(/\s*#\s*/g, "#");
     if (searchInputRef.current) {
       searchInputRef.current.value = cleaned;
     }
@@ -114,7 +114,7 @@ export function LeaderboardDataTableToolbar<TData>({
             }
           }}
           onChange={(event) => {
-            const cleaned = event.target.value.replace(/\s/g, "");
+            const cleaned = event.target.value.replace(/\s*#\s*/g, "#");
             if (event.target.value !== cleaned) {
               event.target.value = cleaned;
             }

--- a/src/components/tables/LeaderboardDataTableToolbar.tsx
+++ b/src/components/tables/LeaderboardDataTableToolbar.tsx
@@ -53,15 +53,16 @@ export function LeaderboardDataTableToolbar<TData>({
   );
 
   const handleSelectHistory = (selectedName: string) => {
+    const cleaned = selectedName.replace(/\s/g, "");
     if (searchInputRef.current) {
-      searchInputRef.current.value = selectedName;
+      searchInputRef.current.value = cleaned;
     }
-    nameColumn.setFilterValue(selectedName);
+    nameColumn.setFilterValue(cleaned);
     navigate({
       viewTransition: true,
       search: (prev) => ({
         ...prev,
-        name: selectedName.length ? selectedName : undefined,
+        name: cleaned.length ? cleaned : undefined,
       }),
     });
     setHistoryOpen(false);
@@ -101,15 +102,28 @@ export function LeaderboardDataTableToolbar<TData>({
             setHistoryOpen(false);
             if (e.target.value) addToHistory(e.target.value);
           }}
+          onKeyDown={(e) => {
+            if (e.key === "Escape") {
+              if (searchInputRef.current) searchInputRef.current.value = "";
+              nameColumn.setFilterValue("");
+              navigate({
+                viewTransition: true,
+                search: (prev) => ({ ...prev, name: undefined }),
+              });
+              setHistoryOpen(false);
+            }
+          }}
           onChange={(event) => {
-            nameColumn.setFilterValue(event.target.value);
+            const cleaned = event.target.value.replace(/\s/g, "");
+            if (event.target.value !== cleaned) {
+              event.target.value = cleaned;
+            }
+            nameColumn.setFilterValue(cleaned);
             navigate({
               viewTransition: true,
               search: (prev) => ({
                 ...prev,
-                name: event.target.value.length
-                  ? event.target.value
-                  : undefined,
+                name: cleaned.length ? cleaned : undefined,
               }),
             });
           }}

--- a/src/routes/compare.tsx
+++ b/src/routes/compare.tsx
@@ -93,10 +93,10 @@ function RouteComponent() {
   const isLoading = queries.some((q) => q.isLoading);
 
   const handleCompare = () => {
-    const trimmed = inputs.map((s) => s.trim()).filter(Boolean);
+    const cleaned = inputs.map((s) => s.replace(/\s/g, "")).filter(Boolean);
     navigate({
       to: "/compare",
-      search: { players: trimmed.length ? trimmed : undefined },
+      search: { players: cleaned.length ? cleaned : undefined },
     });
   };
 

--- a/src/routes/compare.tsx
+++ b/src/routes/compare.tsx
@@ -93,7 +93,7 @@ function RouteComponent() {
   const isLoading = queries.some((q) => q.isLoading);
 
   const handleCompare = () => {
-    const cleaned = inputs.map((s) => s.replace(/\s/g, "")).filter(Boolean);
+    const cleaned = inputs.map((s) => s.replace(/\s*#\s*/g, "#").trim()).filter(Boolean);
     navigate({
       to: "/compare",
       search: { players: cleaned.length ? cleaned : undefined },


### PR DESCRIPTION
Player names never contain spaces, so all search inputs now strip whitespace before filtering/navigating. ESC in the toolbar name filter now clears the input value and resets the URL param.